### PR TITLE
Drop conda-build pinning on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -66,10 +66,6 @@ install:
     - cmd: conda config --add channels conda-forge
     - cmd: conda info
     - cmd: conda install -n root --quiet --yes conda-build anaconda-client jinja2 setuptools
-    # Workaround for Python 3.4 and x64 bug in latest conda-build.
-    # FIXME: Remove once there is a release that fixes the upstream issue
-    # ( https://github.com/conda/conda-build/issues/895 ).
-    - cmd: if "%TARGET_ARCH%" == "x64" if "%CONDA_PY%" == "34" conda install conda-build=1.20.0 --yes
 
 # Skip .NET project specific build phase.
 build: off


### PR DESCRIPTION
This pinning on AppVeyor for Python 3.4 64-bit is keeping `curl` from getting fixes it requires to build properly. We are manually removing this pinning for now. In the future, handling these pinnings will not be part of the CI scripts at all. Instead a package or script will be used instead.