### PR TITLE
Drop `certifi`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 864e7819210b586d42c674a1fdd577ce75a78b3dda64c63565abe5aefd72c753
 
 build:
-  number:  0
+  number:  1
   features:
     - vc9     # [win and py27]
     - vc10    # [win and py34]
@@ -22,11 +22,9 @@ requirements:
     - python      # [win]
     - pkg-config  # [unix]
     - openssl     # [unix]
-    - certifi     # [unix]
     - zlib
   run:
     - openssl     # [unix]
-    - certifi     # [unix]
     - zlib
 
 test:


### PR DESCRIPTION
TL;DR: `curl` depends on `openssl`, which pulls in the certs we need from `ca-certificates`. `certifi` is not used for this.

Originally, we had planned to use `certifi` to get certs. However, `certifi` is a Python package and as such puts these in `site-packages`, which is something we not only don't want or need, but it makes it more difficult to properly configure things. Subsequently, we created `ca-certificates`, which simply takes the certs included in `certifi` and moves them to the right location. In the long term, `ca-certificates` may be constructed in different ways, but will always provide these certs. We decided to make this a run time dependency of `openssl`. So, anything using `openssl` will automatically get certs. As we did make the certs a separate package and we did not pin them in `openssl`, updating the certs in `ca-certificates` will get picked up by `conda update --all`.