### PR TITLE
Fix hardcoded cert path in `curl` libs

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,6 +39,9 @@ test:
     - curl-config --features       # [not win]
     - curl-config --protocols      # [not win]
 
+    # Try downloading something from https to make sure the certs are used correctly.
+    - curl https://raw.githubusercontent.com/conda-forge/curl-feedstock/master/LICENSE
+
 about:
   home: http://curl.haxx.se/
   license: MIT/X derivate (http://curl.haxx.se/docs/copyright.html)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,8 @@ source:
   sha256: 864e7819210b586d42c674a1fdd577ce75a78b3dda64c63565abe5aefd72c753
 
 build:
-  number:  1
+  number: 2
+  detect_binary_files_with_prefix: true
   features:
     - vc9     # [win and py27]
     - vc10    # [win and py34]


### PR DESCRIPTION
Appears the `curl` libraries are hard-coding the path to the certs in their libraries. This is pretty bad. I'm not sure if this will be ok for us to fix, but we need to do it somehow as it is confusing `git` (though I think we have found a way around that) and causing `curl` problems downloading with HTTPS. This is an attempt to fix `curl` so that it uses the certs correctly. Feedback welcome.

cc @msarahan @pelson