### PR TITLE
Update to 7.49.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "7.48.0" %}
+{% set version = "7.49.0" %}
 
 package:
   name: curl
@@ -7,10 +7,10 @@ package:
 source:
   fn: curl-{{ version }}.tar.bz2
   url: http://curl.haxx.se/download/curl-{{ version }}.tar.bz2
-  sha256: 864e7819210b586d42c674a1fdd577ce75a78b3dda64c63565abe5aefd72c753
+  sha256: 14f44ed7b5207fea769ddb2c31bd9e720d37312e1c02315def67923a4a636078
 
 build:
-  number: 2
+  number: 0
   detect_binary_files_with_prefix: true
   features:
     - vc9     # [win and py27]


### PR DESCRIPTION
Updates to `curl` 7.49.0. I don't think we need to do pinnings based on what curl says about [ABI compatibility]( https://curl.haxx.se/libcurl/abi.html ).