### PR TITLE
Add perl for tests on UNIX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@
 language: objective-c
 
 env:
+  matrix:
+    
+    - CONDA_PERL=5.20.3.1
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "fQu0PKeY41yTu/gFdiUmfmZYFZt/5gRkM8PqY48ngtfZIFX/KFph9vKCxHAg3pa4NECyf/8KTvC3hfA1RL5oCfsDgQDz3WF9sYmQmqfEW8FV5xVImv6wnb9y1HhI/VfRvWT32vs1s70ClbGSGvQ5guMcnDvjw/AVn0whtUfbTBkZJrqsRys/GSW1d4jn94ao8oRJ3lat58WmP/pc6j4NdfJCU10cT6BzYJ2wkB/S8qxT4jEB2sjDkMOmoAJSDAc6yqjE8r+RIif+0jjXZjIr0IxG9tInDNO9/ECww7vkR6SRN7jstV4fQBI0x2NLfS4yLZRvjDJyTF14Jh8sNHbGYBK7pZgJ89JktKTy2Pu4/GylLpL39O++/u9++k2REvJVCZtFVp6B+2JCXDFhXp55fx7ozh+U8ORx/jsq3MKH2BDLSzx0jN14MGoxTPU+0d5rcf/tOB+/CSI6NjkafNev7TRfbybRpDQDaWeF6UN7gf0BANmPMuj+YodNh4bqeueorxxAZMLHaKfy/oetRxlZl0okHnqWCrv2b6eUAM8hO92IbL2+knAMCgW/2aGOV9D2D7YYQVeTG5Ojy4Idn1DqED5z8bXmMWnlCXNDe+05NYgg+8IoRELoKaIQTyCf4eU7DaTC8UYw2/EMVpSo0xGkQkWN+sJc53/PWoD1XSDhzRs="

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -44,6 +44,9 @@ conda install --yes conda-build
 conda info
 
 # Embarking on 1 case(s).
+    set -x
+    export CONDA_PERL=5.20.3.1
+    set +x
     conda build /recipe_root --quiet || exit 1
     /feedstock_root/ci_support/upload_or_check_non_existence.py /recipe_root conda-forge --channel=main || exit 1
 EOF

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,8 @@ requirements:
   build:
     # python is a build requirement on Windows to resolve features.
     - python      # [win]
+    # perl is required to run the tests on UNIX.
+    - perl        # [unix]
     - pkg-config  # [unix]
     - openssl     # [unix]
     - zlib


### PR DESCRIPTION
Turns out `curl` requires `perl` to run the tests on UNIX. This can be demonstrated by this CircleCI [build]( https://circleci.com/gh/conda-forge/curl-feedstock/13 ). As the copy of `perl` on the docker image gave us a false sense of having `perl`, we must now address this properly and make `perl` a build dependency.

Didn't bump the build number as this only affects the tests. It doesn't affect the binaries we provide.