### PR TITLE
Disable dtags when linking on Linux

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,6 +7,8 @@ if [ $(uname) == "Darwin" ]; then
     export DYLD_FALLBACK_LIBRARY_PATH="${PREFIX}/lib"
     export CC=clang
     export CXX=clang++
+else
+    export LDFLAGS="$LDFLAGS -Wl,--disable-new-dtags"
 fi
 
 ./configure \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - drop_failing_tests_macos.diff  # [osx]
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win and py36]
   detect_binary_files_with_prefix: True
   features:


### PR DESCRIPTION
Without this, the `libcurl.so` library will have `RUNPATH` set instead of `RPATH`, which means that `LD_LIBRARY_PATH` would have higher precedence when the linker searches for libraries.

Fix https://github.com/conda-forge/curl-feedstock/issues/24 , which I'm also experiencing in a cluster environment where `LD_LIBRARY_PATH` is forcibly set.