### PR TITLE
bump

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - drop_failing_tests_macos.diff  # [osx]
 
 build:
-  number: 3
+  number: 4
 
 requirements:
   build:


### PR DESCRIPTION
Continuing the test to solve https://github.com/conda-forge/netcdf4-feedstock/issues/78, I was able to get a working `netcdf4` locally after rebuilding `libssh2` (https://github.com/conda-forge/libssh2-feedstock/pull/28) &rarr; `curl` &rarr; `netcdf4`. If that is really the solution or if I was just protected from whatever was in AppVeyor will be clear only after I do the same in our CIs.