### PR TITLE
Enable Zstd support for Linux/MacOS

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -18,6 +18,7 @@ fi
     --with-ca-bundle=${PREFIX}/ssl/cacert.pem \
     $USESSL \
     --with-zlib=${PREFIX} \
+    --with-zstd=${PREFIX} \
     --with-gssapi=${PREFIX} \
     --with-libssh2=${PREFIX} \
     --with-nghttp2=${PREFIX} \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 8224b45cce12abde039c12dc0711b7ea85b104b9ad534d6e4c5b4e188a61c907
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -21,6 +21,7 @@ requirements:
     - pkg-config  # [unix]
   host:
     - zlib
+    - zstd  # [unix]
     - krb5
     - libssh2
     - openssl        # [unix]
@@ -37,6 +38,7 @@ outputs:
         - openssl   # [unix]
         - libnghttp2   # [unix]
         - zlib
+        - zstd  # [unix]
         - libssh2
         - krb5
       run:
@@ -76,6 +78,7 @@ outputs:
       host:
         - openssl   # [unix]
         - zlib
+        - zstd  # [unix]
         - libssh2
         - krb5
         - {{ pin_subpackage('libcurl', exact=True) }}
@@ -102,6 +105,7 @@ outputs:
         # both OpenSSL 1.1.1 and 3.0.0 and being supported
         - openssl   # [unix]
         - zlib
+        - zstd  # [unix]
         - libssh2
         - krb5
       run:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
This enables Zstd support for http compressor in curl. Zstd is added as a dependency for unix. The windows Makefile.vc does not currently support Zstd, so windows is left untouched.
<!--
Please add any other relevant info below:
-->
