### PR TITLE
Add a macos static build that (re-)enables securetransport

### DIFF
--- a/.ci_support/linux_64_openssl1.1.1.yaml
+++ b/.ci_support/linux_64_openssl1.1.1.yaml
@@ -16,8 +16,6 @@ libssh2:
 - '1'
 openssl:
 - 1.1.1
-perl:
-- 5.32.1
 target_platform:
 - linux-64
 zlib:

--- a/.ci_support/linux_64_openssl3.yaml
+++ b/.ci_support/linux_64_openssl3.yaml
@@ -16,8 +16,6 @@ libssh2:
 - '1'
 openssl:
 - '3'
-perl:
-- 5.32.1
 target_platform:
 - linux-64
 zlib:

--- a/.ci_support/linux_aarch64_openssl1.1.1.yaml
+++ b/.ci_support/linux_aarch64_openssl1.1.1.yaml
@@ -20,8 +20,6 @@ libssh2:
 - '1'
 openssl:
 - 1.1.1
-perl:
-- 5.32.1
 target_platform:
 - linux-aarch64
 zlib:

--- a/.ci_support/linux_aarch64_openssl3.yaml
+++ b/.ci_support/linux_aarch64_openssl3.yaml
@@ -20,8 +20,6 @@ libssh2:
 - '1'
 openssl:
 - '3'
-perl:
-- 5.32.1
 target_platform:
 - linux-aarch64
 zlib:

--- a/.ci_support/linux_ppc64le_openssl1.1.1.yaml
+++ b/.ci_support/linux_ppc64le_openssl1.1.1.yaml
@@ -16,8 +16,6 @@ libssh2:
 - '1'
 openssl:
 - 1.1.1
-perl:
-- 5.32.1
 target_platform:
 - linux-ppc64le
 zlib:

--- a/.ci_support/linux_ppc64le_openssl3.yaml
+++ b/.ci_support/linux_ppc64le_openssl3.yaml
@@ -16,8 +16,6 @@ libssh2:
 - '1'
 openssl:
 - '3'
-perl:
-- 5.32.1
 target_platform:
 - linux-ppc64le
 zlib:

--- a/.ci_support/osx_64_openssl1.1.1.yaml
+++ b/.ci_support/osx_64_openssl1.1.1.yaml
@@ -16,8 +16,6 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 openssl:
 - 1.1.1
-perl:
-- 5.32.1
 target_platform:
 - osx-64
 zlib:

--- a/.ci_support/osx_64_openssl3.yaml
+++ b/.ci_support/osx_64_openssl3.yaml
@@ -16,8 +16,6 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 openssl:
 - '3'
-perl:
-- 5.32.1
 target_platform:
 - osx-64
 zlib:

--- a/.ci_support/osx_arm64_openssl1.1.1.yaml
+++ b/.ci_support/osx_arm64_openssl1.1.1.yaml
@@ -16,8 +16,6 @@ macos_machine:
 - arm64-apple-darwin20.0.0
 openssl:
 - 1.1.1
-perl:
-- 5.32.1
 target_platform:
 - osx-arm64
 zlib:

--- a/.ci_support/osx_arm64_openssl3.yaml
+++ b/.ci_support/osx_arm64_openssl3.yaml
@@ -16,8 +16,6 @@ macos_machine:
 - arm64-apple-darwin20.0.0
 openssl:
 - '3'
-perl:
-- 5.32.1
 target_platform:
 - osx-arm64
 zlib:

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Current release info
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-curl-green.svg)](https://anaconda.org/conda-forge/curl) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/curl.svg)](https://anaconda.org/conda-forge/curl) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/curl.svg)](https://anaconda.org/conda-forge/curl) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/curl.svg)](https://anaconda.org/conda-forge/curl) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-libcurl-green.svg)](https://anaconda.org/conda-forge/libcurl) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libcurl.svg)](https://anaconda.org/conda-forge/libcurl) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libcurl.svg)](https://anaconda.org/conda-forge/libcurl) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libcurl.svg)](https://anaconda.org/conda-forge/libcurl) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-libcurl--securetransport--static-green.svg)](https://anaconda.org/conda-forge/libcurl-securetransport-static) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libcurl-securetransport-static.svg)](https://anaconda.org/conda-forge/libcurl-securetransport-static) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libcurl-securetransport-static.svg)](https://anaconda.org/conda-forge/libcurl-securetransport-static) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libcurl-securetransport-static.svg)](https://anaconda.org/conda-forge/libcurl-securetransport-static) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-libcurl--static-green.svg)](https://anaconda.org/conda-forge/libcurl-static) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libcurl-static.svg)](https://anaconda.org/conda-forge/libcurl-static) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libcurl-static.svg)](https://anaconda.org/conda-forge/libcurl-static) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libcurl-static.svg)](https://anaconda.org/conda-forge/libcurl-static) |
 
 Installing curl_split_recipe
@@ -145,16 +146,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `curl, libcurl, libcurl-static` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `curl, libcurl, libcurl-securetransport-static, libcurl-static` can be installed with `conda`:
 
 ```
-conda install curl libcurl libcurl-static
+conda install curl libcurl libcurl-securetransport-static libcurl-static
 ```
 
 or with `mamba`:
 
 ```
-mamba install curl libcurl libcurl-static
+mamba install curl libcurl libcurl-securetransport-static libcurl-static
 ```
 
 It is possible to list all of the versions of `curl` available on your platform with `conda`:

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -18,12 +18,4 @@ nmake /f Makefile.vc mode=static VC=%VS_MAJOR:"=% WITH_DEVEL=%LIBRARY_PREFIX% ^
          MACHINE=%ARCH_STRING% ENABLE_UNICODE=yes
 if errorlevel 1 exit 1
 
-REM install static library
-copy ..\builds\libcurl-vc%VS_MAJOR:"=%-%ARCH_STRING%-release-static-zlib-dll-ssh2-dll-ipv6-sspi-schannel\lib\libcurl_a.lib %LIBRARY_PREFIX%\lib\libcurl_a.lib
-if %ERRORLEVEL% GTR 3 exit 1
-
-REM install everything else
-robocopy ..\builds\libcurl-vc%VS_MAJOR:"=%-%ARCH_STRING%-release-dll-zlib-dll-ssh2-dll-ipv6-sspi-schannel\ %LIBRARY_PREFIX% *.* /E
-if %ERRORLEVEL% GTR 3 exit 1
-
 exit 0

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,12 +5,18 @@ cp $BUILD_PREFIX/share/libtool/build-aux/config.* .
 # need macosx-version-min flags set in cflags and not cppflags
 export CFLAGS="$CFLAGS $CPPFLAGS"
 
+if [[ "${PKG_NAME}" == "libcurl-securetransport-static" ]]; then
+    USESSL="--with-secure-transport"
+    STATIC_BUILD="--enable-static --disable-shared"
+else
+    USESSL="--with-openssl=${PREFIX}"
+fi
 ./configure \
     --prefix=${PREFIX} \
     --host=${HOST} \
     --disable-ldap \
     --with-ca-bundle=${PREFIX}/ssl/cacert.pem \
-    --with-ssl=${PREFIX} \
+    $USESSL $STATIC_BUILD \
     --with-zlib=${PREFIX} \
     --with-gssapi=${PREFIX} \
     --with-libssh2=${PREFIX} \
@@ -18,9 +24,3 @@ export CFLAGS="$CFLAGS $CPPFLAGS"
 || cat config.log
 
 make -j${CPU_COUNT} ${VERBOSE_AT}
-# TODO :: test 1119... exit FAILED
-# make test
-make install
-
-# Includes man pages and other miscellaneous.
-rm -rf "${PREFIX}/share"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -24,3 +24,6 @@ fi
 || cat config.log
 
 make -j${CPU_COUNT} ${VERBOSE_AT}
+
+# TODO :: test 1119... exit FAILED
+# make test

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -27,3 +27,8 @@ make -j${CPU_COUNT} ${VERBOSE_AT}
 
 # TODO :: test 1119... exit FAILED
 # make test
+
+if [[ "${PKG_NAME}" == "libcurl-securetransport-static" ]]; then
+    make install
+    rm $PREFIX/bin/curl
+fi

--- a/recipe/install.bat
+++ b/recipe/install.bat
@@ -1,0 +1,36 @@
+cd winbuild
+
+if %ARCH% == 32 (
+    set ARCH_STRING=x86
+) else (
+    set ARCH_STRING=x64
+)
+
+REM This is implicitly using WinSSL.  See Makefile.vc for more info.
+nmake /f Makefile.vc MODE=dll VC=%VS_MAJOR:"=% WITH_DEVEL=%LIBRARY_PREFIX% ^
+         WITH_ZLIB=dll WITH_SSH2=dll DEBUG=no ENABLE_IDN=no ENABLE_SSPI=yes ^
+         MACHINE=%ARCH_STRING% ENABLE_UNICODE=yes
+if errorlevel 1 exit 1
+
+REM This is implicitly using WinSSL.  See Makefile.vc for more info.
+nmake /f Makefile.vc mode=static VC=%VS_MAJOR:"=% WITH_DEVEL=%LIBRARY_PREFIX% ^
+         WITH_ZLIB=dll WITH_SSH2=dll DEBUG=no ENABLE_IDN=no ENABLE_SSPI=yes ^
+         MACHINE=%ARCH_STRING% ENABLE_UNICODE=yes
+if errorlevel 1 exit 1
+
+REM install static library
+if %PKG_NAME% == "libcurl-static" (
+    copy ..\builds\libcurl-vc%VS_MAJOR:"=%-%ARCH_STRING%-release-static-zlib-dll-ssh2-dll-ipv6-sspi-schannel\lib\libcurl_a.lib %LIBRARY_PREFIX%\lib\libcurl_a.lib
+    if %ERRORLEVEL% GTR 3 exit 1
+)
+
+REM install everything else
+robocopy ..\builds\libcurl-vc%VS_MAJOR:"=%-%ARCH_STRING%-release-dll-zlib-dll-ssh2-dll-ipv6-sspi-schannel\ %LIBRARY_PREFIX% *.* /E
+if %ERRORLEVEL% GTR 3 exit 1
+
+if NOT %PKG_NAME% == "curl" (
+    del %LIBRARY_PREFIX%\bin\curl
+    if %ERRORLEVEL% GTR 3 exit 1
+)
+
+exit 0

--- a/recipe/install.bat
+++ b/recipe/install.bat
@@ -7,7 +7,7 @@ if %ARCH% == 32 (
 )
 
 REM install static library
-if %PKG_NAME% == "libcurl-static" (
+if "%PKG_NAME%" == "libcurl-static" (
     copy ..\builds\libcurl-vc%VS_MAJOR:"=%-%ARCH_STRING%-release-static-zlib-dll-ssh2-dll-ipv6-sspi-schannel\lib\libcurl_a.lib %LIBRARY_PREFIX%\lib\libcurl_a.lib
     if %ERRORLEVEL% GTR 3 exit 1
 )
@@ -16,8 +16,8 @@ REM install everything else
 robocopy ..\builds\libcurl-vc%VS_MAJOR:"=%-%ARCH_STRING%-release-dll-zlib-dll-ssh2-dll-ipv6-sspi-schannel\ %LIBRARY_PREFIX% *.* /E
 if %ERRORLEVEL% GTR 3 exit 1
 
-if NOT %PKG_NAME% == "curl" (
-    del %LIBRARY_PREFIX%\bin\curl.exe
+if not "%PKG_NAME%" == "curl" (
+    del /f %LIBRARY_PREFIX%\bin\curl.exe
     if %ERRORLEVEL% GTR 3 exit 1
 )
 

--- a/recipe/install.bat
+++ b/recipe/install.bat
@@ -17,7 +17,7 @@ robocopy ..\builds\libcurl-vc%VS_MAJOR:"=%-%ARCH_STRING%-release-dll-zlib-dll-ss
 if %ERRORLEVEL% GTR 3 exit 1
 
 if NOT %PKG_NAME% == "curl" (
-    del %LIBRARY_PREFIX%\bin\curl
+    del %LIBRARY_PREFIX%\bin\curl.exe
     if %ERRORLEVEL% GTR 3 exit 1
 )
 

--- a/recipe/install.bat
+++ b/recipe/install.bat
@@ -6,18 +6,6 @@ if %ARCH% == 32 (
     set ARCH_STRING=x64
 )
 
-REM This is implicitly using WinSSL.  See Makefile.vc for more info.
-nmake /f Makefile.vc MODE=dll VC=%VS_MAJOR:"=% WITH_DEVEL=%LIBRARY_PREFIX% ^
-         WITH_ZLIB=dll WITH_SSH2=dll DEBUG=no ENABLE_IDN=no ENABLE_SSPI=yes ^
-         MACHINE=%ARCH_STRING% ENABLE_UNICODE=yes
-if errorlevel 1 exit 1
-
-REM This is implicitly using WinSSL.  See Makefile.vc for more info.
-nmake /f Makefile.vc mode=static VC=%VS_MAJOR:"=% WITH_DEVEL=%LIBRARY_PREFIX% ^
-         WITH_ZLIB=dll WITH_SSH2=dll DEBUG=no ENABLE_IDN=no ENABLE_SSPI=yes ^
-         MACHINE=%ARCH_STRING% ENABLE_UNICODE=yes
-if errorlevel 1 exit 1
-
 REM install static library
 if %PKG_NAME% == "libcurl-static" (
     copy ..\builds\libcurl-vc%VS_MAJOR:"=%-%ARCH_STRING%-release-static-zlib-dll-ssh2-dll-ipv6-sspi-schannel\lib\libcurl_a.lib %LIBRARY_PREFIX%\lib\libcurl_a.lib

--- a/recipe/install.sh
+++ b/recipe/install.sh
@@ -1,5 +1,5 @@
-# TODO :: test 1119... exit FAILED
-# make test
+#!/bin/bash
+
 make install
 
 # Includes man pages and other miscellaneous.

--- a/recipe/install.sh
+++ b/recipe/install.sh
@@ -1,0 +1,15 @@
+# TODO :: test 1119... exit FAILED
+# make test
+make install
+
+# Includes man pages and other miscellaneous.
+rm -rf "${PREFIX}/share"
+
+if [[ "${PKG_NAME}" == "libcurl" ]]; then
+	rm $PREFIX/lib/libcurl.a
+	rm $PREFIX/bin/curl
+elif [[ "${PKG_NAME}" == "libcurl-static" || "${PKG_NAME}" == "libcurl-securetransport-static" ]]; then
+	rm $PREFIX/bin/curl
+elif [[ "${PKG_NAME}" == "curl" ]]; then
+	rm $PREFIX/lib/libcurl.a
+fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -89,7 +89,7 @@ outputs:
   - name: libcurl-securetransport-static
     build:
       skip: true  # [not osx]
-    script: install.sh  # [unix]
+    script: build.sh  # [unix]
     requirements:
       build:
         - libtool     # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -109,6 +109,8 @@ outputs:
     test:
       commands:
         - test -f $PREFIX/lib/libcurl.a  # [not win]
+        - CURL_SSL_BACKENDS=$(curl-config --ssl-backends)
+        - if ! echo $CURL_SSL_BACKENDS | grep -q "Secure Transport"; then exit 1; fi
 
   - name: curl
     script: install.sh  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,6 @@ requirements:
     - libnghttp2     # [unix]
     - zlib
 
-
 outputs:
   - name: libcurl
     script: install.sh  # [unix]
@@ -90,7 +89,8 @@ outputs:
         - if not exist %LIBRARY_LIB%\libcurl_a.lib exit 1  # [win]
 
   - name: libcurl-securetransport-static
-    skip: true  # [not osx]
+    build:
+      skip: true  # [not osx]
     script: install.sh  # [unix]
     requirements:
       build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ requirements:
     - {{ compiler('c') }}
     - make             # [unix]
     # perl is required to run the tests on UNIX.
-    - perl  # [unix]
+    # - perl  # [unix]
     - pkg-config  # [unix]
   host:
     - zlib
@@ -30,6 +30,8 @@ requirements:
 
 outputs:
   - name: libcurl
+    script: install.sh  # [unix]
+    script: install.bat  # [win]
     requirements:
       build:
         - {{ compiler('c') }}
@@ -66,6 +68,8 @@ outputs:
         - if not exist %LIBRARY_BIN%\libcurl.dll exit 1   # [win]
 
   - name: libcurl-static
+    script: install.sh  # [unix]
+    script: install.bat  # [win]
     requirements:
       build:
         - {{ compiler('c') }}
@@ -85,7 +89,32 @@ outputs:
         - test -f $PREFIX/lib/libcurl.a  # [not win]
         - if not exist %LIBRARY_LIB%\libcurl_a.lib exit 1  # [win]
 
+  - name: libcurl-securetransport-static
+    skip: true  # [not osx]
+    script: install.sh  # [unix]
+    requirements:
+      build:
+        - libtool  # [unix]
+        - {{ compiler('c') }}
+        - make             # [unix]
+        # perl is required to run the tests on UNIX.
+        # - perl  # [unix]
+        - pkg-config  # [unix]
+      host:
+        - libnghttp2   # [unix]
+        - libssh2
+        - zlib
+        - krb5
+      run:
+        - libnghttp2   # [unix]
+
+    test:
+      commands:
+        - test -f $PREFIX/lib/libcurl.a  # [not win]
+
   - name: curl
+    script: install.sh  # [unix]
+    script: install.bat  # [win]
     files:
       - bin/curl               # [unix]
       - Library/bin/curl.exe*   # [win]
@@ -110,6 +139,7 @@ outputs:
         # Try downloading something from https to make sure the certs are used correctly.
         - curl https://raw.githubusercontent.com/conda-forge/curl-feedstock/master/LICENSE.txt
         - if not exist %LIBRARY_BIN%\curl.exe exit 1  # [win]
+        - if exist %LIBRARY_LIB%\libcurl_a.lib exit 1  # [win]
 
 about:
   home: http://curl.haxx.se/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ requirements:
     - {{ compiler('c') }}
     - make             # [unix]
     # perl is required to run the tests on UNIX.
-    # - perl  # [unix]
+    - perl  # [unix]
     - pkg-config  # [unix]
   host:
     - zlib
@@ -34,6 +34,8 @@ outputs:
     requirements:
       build:
         - {{ compiler('c') }}
+        - make                # [unix]
+        - libtool             # [unix]
       host:
         - openssl   # [unix]
         - libnghttp2   # [unix]
@@ -46,25 +48,19 @@ outputs:
     build:
       run_exports:
         - {{ pin_subpackage('libcurl') }}
-    files:
-      - include/curl             # [unix]
-      - lib/libcurl.so*          # [linux]
-      - lib/libcurl*.dylib       # [osx]
-      - lib/pkgconfig/libcurl*   # [unix]
-      - bin/curl-config          # [unix]
-      - Library/bin/libcurl.dll  # [win]
-      - Library/include/curl     # [win]
-      - Library/lib/libcurl.lib  # [win]
-      - Library/lib/libcurl.exp  # [win]
     test:
       commands:
         - curl-config --features       # [not win]
         - curl-config --protocols      # [not win]
         - test -f ${PREFIX}/lib/libcurl${SHLIB_EXT}  # [not win]
+        - test -f ${PREFIX}/include/curl/curl.h  # [not win]
         - test ! -f ${PREFIX}/lib/libcurl.a          # [not win]
         - if exist %LIBRARY_BIN%\curl.exe exit 1     # [win]
         - if exist %LIBRARY_LIB%\libcurl_a.lib exit 1     # [win]
         - if not exist %LIBRARY_BIN%\libcurl.dll exit 1   # [win]
+        - if not exist %LIBRARY_LIB%\libcurl.exp exit 1   # [win]
+        - if not exist %LIBRARY_LIB%\libcurl.lib exit 1   # [win]
+        - if not exist %LIBRARY_PREFIX%\include\curl\curl.h exit 1   # [win]
 
   - name: libcurl-static
     script: install.sh  # [unix]
@@ -72,6 +68,8 @@ outputs:
     requirements:
       build:
         - {{ compiler('c') }}
+        - make                # [unix]
+        - libtool             # [unix]
       host:
         - openssl   # [unix]
         - zlib
@@ -94,14 +92,14 @@ outputs:
     script: install.sh  # [unix]
     requirements:
       build:
-        - libtool  # [unix]
+        - libtool     # [unix]
         - {{ compiler('c') }}
-        - make             # [unix]
+        - make        # [unix]
         # perl is required to run the tests on UNIX.
-        # - perl  # [unix]
+        - perl        # [unix]
         - pkg-config  # [unix]
       host:
-        - libnghttp2   # [unix]
+        - libnghttp2  # [unix]
         - libssh2
         - zlib
         - krb5
@@ -115,12 +113,11 @@ outputs:
   - name: curl
     script: install.sh  # [unix]
     script: install.bat  # [win]
-    files:
-      - bin/curl               # [unix]
-      - Library/bin/curl.exe*   # [win]
     requirements:
       build:
         - {{ compiler('c') }}
+        - make                # [unix]
+        - libtool             # [unix]
       host:
         - {{ pin_subpackage('libcurl', exact=True) }}
         # OpenSSL is needed here to prevent conda-build from getting confused while


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
