### PR TITLE
Enable linux-riscv64

### DIFF
--- a/.ci_support/linux_riscv64_.yaml
+++ b/.ci_support/linux_riscv64_.yaml
@@ -1,0 +1,32 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '15'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.39'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+krb5:
+- '1.22'
+libcurl:
+- '8'
+libpsl:
+- '0.22'
+libssh2:
+- '1'
+openssl:
+- '3.5'
+perl:
+- 5.32.1
+target_platform:
+- linux-riscv64
+zlib:
+- '1'
+zstd:
+- '1.5'

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -58,6 +58,18 @@ jobs:
             resize_partitions: False
             runs_on: ['ubuntu-latest']
             tools_install_dir: ~/miniforge3
+          - CONFIG: linux_riscv64_
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            build_workspace_dir: build_artifacts
+            docker_run_args: 
+            free_disk_space: skip
+            os: ubuntu
+            pagefile_size: 0
+            resize_partitions: False
+            runs_on: ['ubuntu-latest']
+            tools_install_dir: ~/miniforge3
     steps:
 
     - name: Checkout code

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,5 +1,6 @@
 build_platform:
   linux_ppc64le: linux_64
+  linux_riscv64: linux_64
   win_arm64: win_64
 conda_build:
   pkg_format: '2'
@@ -9,5 +10,6 @@ github:
   tooling_branch_name: main
 provider:
   linux_aarch64: default
+  linux_riscv64: default
   osx_arm64: default
 test: native_and_emulated


### PR DESCRIPTION
Enables building for linux-riscv64 by adding `build_platform` and `provider` entries to `conda-forge.yml`, then re-rendering with conda-smithy.