### PR TITLE
Rebuild `libcurl-static` with `libpsl-static`

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -11,7 +11,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 krb5:
 - '1.22'
 libcurl:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -11,7 +11,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-aarch64:alma9
+- quay.io/condaforge/linux-anvil-aarch64:alma10
 krb5:
 - '1.22'
 libcurl:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -11,7 +11,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 krb5:
 - '1.22'
 libcurl:

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         include:
           - CONFIG: linux_64_
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
@@ -35,7 +35,7 @@ jobs:
             runs_on: ['ubuntu-latest']
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_aarch64_
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
@@ -47,7 +47,7 @@ jobs:
             runs_on: ['ubuntu-24.04-arm']
             tools_install_dir: ~/miniforge3
           - CONFIG: linux_ppc64le_
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -35,9 +35,22 @@ if errorlevel 1 exit 1
 cmake --build . --target install --config "%CMAKE_CONFIG%" -- -v
 if errorlevel 1 exit 1
 
-:: Build and install static libraries
+:: Build and install static libraries in a separate build tree so the shared
+:: configure cache does not keep the DLL import library for libpsl.
+:: Compile with PSL_STATIC so objects reference psl_* instead of __imp_psl_*.
+:: See: https://github.com/mamba-org/mamba/pull/4355
+popd
+mkdir build_static_%CMAKE_CONFIG%
+pushd build_static_%CMAKE_CONFIG%
+
+set "CMAKE_STATIC_LIBPSL_ARGS="
+if not "%target_platform%"=="win-arm64" (
+    set "CFLAGS=%CFLAGS% -DPSL_STATIC"
+    set "CMAKE_STATIC_LIBPSL_ARGS=-D LIBPSL_LIBRARY:FILEPATH=%LIBRARY_LIB%\libpsl.a"
+)
 cmake -G "Ninja" ^
     %CMAKE_ARGS% ^
+    %CMAKE_STATIC_LIBPSL_ARGS% ^
     -D BUILD_CURL_EXE:BOOL=OFF ^
     -D BUILD_SHARED_LIBS:BOOL=OFF ^
     -D BUILD_STATIC_LIBS:BOOL=ON ^

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: ad6f2f94934b38e31e48272833c99b891d045b4565fe942a53fbd27bd3910e16
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:
@@ -29,6 +29,8 @@ requirements:
     - zlib
     - zstd           # [unix]
     - libpsl  # [not (win and arm64)]
+    # Needed so the Windows static libcurl build can link libpsl.a with PSL_STATIC.
+    - libpsl-static  # [not (win and arm64)]
 
 outputs:
   - name: libcurl
@@ -86,7 +88,7 @@ outputs:
         - zstd  # [unix]
         - libssh2
         - krb5
-        - libpsl  # [not (win and arm64)]
+        - libpsl-static  # [not (win and arm64)]
         - {{ pin_subpackage('libcurl', exact=True) }}
       run:
         - {{ pin_subpackage('libcurl', exact=True) }}


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.


---

- Build Windows `libcurl-static` against `libpsl-static` with `-DPSL_STATIC`, so object files reference undecorated `psl_*` symbols instead of DLL imports (`__imp_psl_*`).
- Use a separate CMake build tree for the static pass and point `LIBPSL_LIBRARY` at `libpsl.a`.
- Bump build number to 3.

This unblocks static micromamba linking on Windows (see [mamba-org/mamba#4355](https://github.com/mamba-org/mamba/pull/4355) and [conda-forge/micromamba-feedstock#304](https://github.com/conda-forge/micromamba-feedstock/pull/304)), where `libcurl_a.lib` currently fails with unresolved `__imp_psl_*` when linked with `libpsl.a`.
